### PR TITLE
Update to comply with new 2-arg arity of IJavaScriptEnv in 0.0-2665.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weasel "0.4.3-SNAPSHOT"
+(defproject weasel "0.5.0-SNAPSHOT"
   :description "websocket REPL environment for ClojureScript"
   :url "http://github.com/tomjakubowski/weasel"
   :license {:name "Unlicense"
@@ -6,8 +6,8 @@
             :distribution :repo}
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2371" :scope "provided"]
-                 [org.clojure/google-closure-library "0.0-20140226-71326067" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2665" :scope "provided"]
+                 [org.clojure/google-closure-library "0.0-20140718-946a7d39" :scope "provided"]
                  [http-kit "2.1.18"]]
 
   :repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
Since this is a breaking change, update Weasel version to 0.5.0.
Additionally, since this is incompatible with ClojureScript versions
prior to 0.0-2665, eliminate the temporary compatibility hack for
previous API breakage introduced with 0.0-2371.

This addresses #37. If this is ultimately released, the CHANGES.md
can be updated to reflect the breaking change, along with README.md.