### PR TITLE
Fix compatibility with new Clojurescript releases (>0.0.2755)

### DIFF
--- a/src/clj/weasel/repl/websocket.clj
+++ b/src/clj/weasel/repl/websocket.clj
@@ -40,9 +40,9 @@
   "Returns a JS environment to pass to repl or piggieback"
   [& {:as opts}]
   (let [ups-deps (cljsc/get-upstream-deps (java.lang.ClassLoader/getSystemClassLoader))
-        opts (assoc opts
-               :ups-libs (:libs ups-deps)
-               :ups-foreign-libs (:foreign-libs ups-deps))
+        opts (merge {:ups-libs (:libs ups-deps)
+                     :ups-foreign-libs (:foreign-libs ups-deps)}
+                    opts)
         compiler-env (env/default-compiler-env opts)
         opts (merge (WebsocketEnv.)
                {::env/compiler compiler-env

--- a/src/clj/weasel/repl/websocket.clj
+++ b/src/clj/weasel/repl/websocket.clj
@@ -39,7 +39,11 @@
 (defn repl-env
   "Returns a JS environment to pass to repl or piggieback"
   [& {:as opts}]
-  (let [compiler-env (env/default-compiler-env opts)
+  (let [ups-deps (cljsc/get-upstream-deps (java.lang.ClassLoader/getSystemClassLoader))
+        opts (assoc opts
+               :ups-libs (:libs ups-deps)
+               :ups-foreign-libs (:foreign-libs ups-deps))
+        compiler-env (env/default-compiler-env opts)
         opts (merge (WebsocketEnv.)
                {::env/compiler compiler-env
                 :ip "127.0.0.1"

--- a/src/cljs/weasel/repl.cljs
+++ b/src/cljs/weasel/repl.cljs
@@ -80,4 +80,27 @@
         (when verbose (.error js/console "WebSocket error" evt))
         (when (fn? on-error) (on-error evt))))
 
+    ;; Monkey-patch goog.require if running under optimizations :none - David
+    ;; This is copied from Clojurescript (cljs.browser.repl/connect).
+    (when-not js/COMPILED
+      (set! *loaded-libs*
+        (let [gntp (.. js/goog -dependencies_ -nameToPath)]
+          (into #{}
+            (filter
+              (fn [name]
+                (aget (.. js/goog -dependencies_ -visited) (aget gntp name)))
+              (js-keys gntp)))))
+      (set! (.-isProvided_ js/goog) (fn [_] false))
+      (set! (.-require js/goog)
+        (fn [name reload]
+          (when (or (not (contains? *loaded-libs* name)) reload)
+            (set! *loaded-libs* (conj (or *loaded-libs* #{}) name))
+            (.appendChild js/document.body
+              (let [script (.createElement js/document "script")]
+                (set! (.-type script) "text/javascript")
+                (set! (.-src script)
+                  (str js/goog.basePath
+                    (aget (.. js/goog -dependencies_ -nameToPath) name)))
+                script))))))
+
     (net/connect repl-connection repl-server-url)))


### PR DESCRIPTION
The last few Clojurescript releases broke weasel when requiring namespaces. This patch backports necessary changes from ```cljs.browser.repl``` to weasel.

1992a25 gathers upstream (js) dependencies and passes them down to the compiler. Same approach as https://github.com/clojure/clojurescript/commit/5a353c418769cc6d4c212db87e5f51b9511f7c33#diff-0e96f4c891374eb4ed736a5bdbb1b07dR273

74aa18e monkey-patches ```goog.require``` to be a no-op, like https://github.com/clojure/clojurescript/commit/5a353c418769cc6d4c212db87e5f51b9511f7c33#diff-c706571c79101d1f03c9f7073570741eR112

This fixes #43 - but depends on a clojurescript-release containing http://dev.clojure.org/jira/browse/CLJS-1002 (which isn't fixed yet). This is necessary because weasel runs ```cljs.closure/get-upstream-deps``` from a non-main thread & the function uses the current Thread's classloader. The JIRA-ticket makes ```get-upstream-deps``` take an optional argument which is then used as the classloader.