### PR TITLE
Load upstream dependencies.

### DIFF
--- a/src/clj/weasel/repl/websocket.clj
+++ b/src/clj/weasel/repl/websocket.clj
@@ -39,7 +39,11 @@
 (defn repl-env
   "Returns a JS environment to pass to repl or piggieback"
   [& {:as opts}]
-  (let [compiler-env (env/default-compiler-env opts)
+  (let [ups-deps (cljsc/get-upstream-deps (java.lang.ClassLoader/getSystemClassLoader))
+        opts (assoc opts
+                    :ups-libs (:libs ups-deps)
+                    :ups-foreign-libs (:foreign-libs ups-deps))
+        compiler-env (env/default-compiler-env opts)
         opts (merge (WebsocketEnv.)
                {::env/compiler compiler-env
                 :ip "127.0.0.1"


### PR DESCRIPTION
I found that when running weasel from the repl

```clojure
(defn weasel-repl []
  (piggieback/cljs-repl :repl-env (weasel/repl-env :ip "0.0.0.0" :port 9001)))
```

the repl-env does not include upstream dependencies (via clojurescript's new deps.clj mechanism).

This prevents me from being able to use piggieback with Om's new cljsjs dependency on React.

