### PR TITLE
Patching goog.require is wrong

### DIFF
--- a/src/cljs/weasel/repl.cljs
+++ b/src/cljs/weasel/repl.cljs
@@ -88,6 +88,14 @@
         (fn [name]
           (set! (.-isProvided_ js/goog) (fn [name] false))
           (.provide__ js/goog name)
-          (set! (.-isProvided_ js/goog) js/goog.isProvided___))))
+          (set! (.-isProvided_ js/goog) js/goog.isProvided___)))
+      (set! (.-writeScriptTag_ js/goog)
+        (fn [src opt_sourceText]
+          (let [doc js/goog.global.document]
+            (if (nil? opt_sourceText)
+              (.write doc
+                (str "<script type=\"text/javascript\" src=\"" src "\"></script>"))
+              (.write doc
+                (str "<script type=\"text/javascript\">" opt_sourceText "</script>")))))))
 
     (net/connect repl-connection repl-server-url)))

--- a/src/cljs/weasel/repl.cljs
+++ b/src/cljs/weasel/repl.cljs
@@ -84,6 +84,6 @@
     (when-not js/COMPILED
       (set! (.-provide js/goog)
         (fn [name]
-          (.constructNamespace js/goog name))))
+          (.constructNamespace_ js/goog name))))
 
     (net/connect repl-connection repl-server-url)))

--- a/src/cljs/weasel/repl.cljs
+++ b/src/cljs/weasel/repl.cljs
@@ -82,8 +82,12 @@
 
     ;; Monkey-patch goog.provide if running under optimizations :none - David
     (when-not js/COMPILED
+      (set! (.-provide__ js/goog) js/goog.provide)
+      (set! (.-isProvided___ js/goog) js/goog.isProvided_)
       (set! (.-provide js/goog)
         (fn [name]
-          (.constructNamespace_ js/goog name))))
+          (set! (.-isProvided_ js/goog) (fn [name] false))
+          (.provide__ js/goog name)
+          (set! (.-isProvided_ js/goog) js/goog.isProvided___))))
 
     (net/connect repl-connection repl-server-url)))


### PR DESCRIPTION
Instead we need to patch `goog.provide` and `goog.writeScriptTag_`. The previous approach will fail when loading namespaces never explicitly required in the client code. This fix has been landed in ClojureScript master already for the browser REPL.