### PR TITLE
Update README to match new `cljs-repl` signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ an address to bind to (defaults to "127.0.0.1").
 user> (require 'weasel.repl.websocket)
 nil
 user> (cemerick.piggieback/cljs-repl
-        :repl-env (weasel.repl.websocket/repl-env
-                   :ip "0.0.0.0" :port 9001))
+        (weasel.repl.websocket/repl-env
+          :ip "0.0.0.0" :port 9001))
 
 << started Weasel server on ws://0.0.0.0:9001 >>
 Type `:cljs/quit` to stop the ClojureScript REPL


### PR DESCRIPTION
"fix CHANGES to note that `cljs-repl`'s signature now matches `cljs.repl/repl`": https://github.com/cemerick/piggieback/commit/2afde28ce2da195a9b54f8c7096e0749e76daec1