### PR TITLE
add callback to websocket-setup-env

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                               [:name "Tom Jakubowski"]
                               [:email "tom@crystae.net"]
                               [:url "https://github.com/tomjakubowski"]]]
-  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.1.5"]]}}
+  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.1"]]}}
   :source-paths ["src/clj" "src/cljs"]
   :scm {:name "git"
         :url "https://github.com/tomjakubowski/weasel"})

--- a/src/clj/weasel/repl/websocket.clj
+++ b/src/clj/weasel/repl/websocket.clj
@@ -64,10 +64,12 @@
     (fn [data] (process-message this (read-string data)))
     :ip (:ip this)
     :port (:port this))
-  (let [{:keys [ip port]} this]
-    (println (str "<< started Weasel server on ws://" ip ":" port " >>"))
+  (let [{:keys [ip pre-connect]} this]
+    (let [port (-> @server/state :server meta :local-port)]
+      (println (str "<< started Weasel server on ws://" ip ":" port " >>")))
     (print "<< waiting for client to connect ... ")
     (flush)
+    (when pre-connect (pre-connect))
     (server/wait-for-client)
     (println " connected! >>")))
 


### PR DESCRIPTION
As mentioned in #63, I need to be able to determine a port where weasel is listening in order to connect there. What do you think of this approach?